### PR TITLE
Separating framework and legacylib pipelines in diferent workflows

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -1,0 +1,23 @@
+name: Framework Validation
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  release:
+
+  workflow_dispatch:
+
+env:
+  CMAKE_BUILD_TYPE: Release
+  REST_PATH: /rest/legacylib/install
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-validation:
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@submodule-validation

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,17 +1,13 @@
 name: Validation
 
 on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-  release:
-
   workflow_dispatch:
+  workflow_call:
 
 env:
   CMAKE_BUILD_TYPE: Release
   REST_PATH: /rest/legacylib/install
+  LEGACY_LIB_PATH: legacylib
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 defaults:
@@ -19,8 +15,6 @@ defaults:
     shell: bash
 
 jobs:
-  framework-validation:
-    uses: rest-for-physics/framework/.github/workflows/validation.yml@master
 
   build-legacylib:
     name: Build only legacy


### PR DESCRIPTION
These changes are required to avoid concurrency inside submodule validation that is now triggered from framework:

Separated validation files for framework and submodules

Contributes to https://github.com/rest-for-physics/framework/issues/372