### PR TITLE
Replacing custom branch pipeline by master

### DIFF
--- a/.github/workflows/frameworkValidation.yml
+++ b/.github/workflows/frameworkValidation.yml
@@ -20,4 +20,4 @@ defaults:
 
 jobs:
   framework-validation:
-    uses: rest-for-physics/framework/.github/workflows/validation.yml@submodule-validation
+    uses: rest-for-physics/framework/.github/workflows/validation.yml@master


### PR DESCRIPTION
Custom branch was added to the different submodules pipelines at https://github.com/rest-for-physics/framework/pull/371, adding master branch to avoid potential pipeline issues

Related PR
https://github.com/rest-for-physics/framework/pull/377